### PR TITLE
Support extended Sales Navigator ID prefixes (ACwAA/ACoAA) and normalize canonical case

### DIFF
--- a/src/__tests__/salesNavIdExtractor.test.js
+++ b/src/__tests__/salesNavIdExtractor.test.js
@@ -54,6 +54,14 @@ describe('extractSalesNavIdFromUrl', () => {
       expect(result).toBe('acwaaa0cm4mba9l9zimkopy1otohmypitrlogya');
     });
 
+    test('recruiterUrl format with ACoAAB prefix', () => {
+      const url =
+        'www.linkedin.com/talent/profile/acoaabhsj7ybkdwjpapp3d5higdd5blxqaal78a';
+      const result = extractSalesNavIdFromUrl(url);
+
+      expect(result).toBe('acoaabhsj7ybkdwjpapp3d5higdd5blxqaal78a');
+    });
+
     test('recruiterUrl format with https', () => {
       const url =
         'https://www.linkedin.com/talent/profile/ACwAAA0CM4MBa9l9ZiMKoPY1oTohmYpITrloGYA';
@@ -150,6 +158,14 @@ describe('extractSalesNavIdFromUrl', () => {
       const result = extractSalesNavIdFromUrl(url);
 
       expect(result).toBe('ACoAAA0CM4MBva7a2Z-_uLwWoO2swdf5ye_nV2E');
+    });
+
+    test('ACoAAB variant (mixed case)', () => {
+      const url =
+        'www.linkedin.com/sales/people/ACoAABhsj7yBKDWJpapp3d5higdd5blxqaal78a';
+      const result = extractSalesNavIdFromUrl(url);
+
+      expect(result).toBe('ACoAABhsj7yBKDWJpapp3d5higdd5blxqaal78a');
     });
   });
 
@@ -337,6 +353,11 @@ describe('normalizeToCanonicalCase', () => {
   test('Normalizes lowercase ACoAAA to canonical', () => {
     const result = normalizeToCanonicalCase('acoaaa0cm4mbva7a2z-_ulwwoo2swdf5ye_nv2e');
     expect(result).toBe('ACoAAA0cm4mbva7a2z-_ulwwoo2swdf5ye_nv2e');
+  });
+
+  test('Normalizes lowercase ACoAAB to canonical', () => {
+    const result = normalizeToCanonicalCase('acoaabhsj7ybkdwjpapp3d5higdd5blxqaal78a');
+    expect(result).toBe('ACoAABhsj7ybkdwjpapp3d5higdd5blxqaal78a');
   });
 
   test('Preserves already-canonical ACwAAA', () => {

--- a/src/controllers/healthController.js
+++ b/src/controllers/healthController.js
@@ -183,7 +183,7 @@ async function getCoverageBreakdown(req, res) {
 
     // Count by primary identity source (what _id format they use)
     const salesNavPeople = await Person.countDocuments({
-      _id: { $regex: /^ACwAAA/ }
+      _id: { $regex: /^AC[ow]AA/ }
     });
 
     const numericPeople = await Person.countDocuments({

--- a/src/services/identityResolverService.js
+++ b/src/services/identityResolverService.js
@@ -152,7 +152,7 @@ class IdentityResolverService {
 
     return people.reduce((winner, candidate) => {
       // Rule 1: Prefer Sales Nav ID format
-      const salesNavPattern = /^(ACwAAA|ACoAAA)/;
+      const salesNavPattern = /^(ACwAA|ACoAA)/;
       const winnerHasSalesNav = salesNavPattern.test(winner._id);
       const candidateHasSalesNav = salesNavPattern.test(candidate._id);
 

--- a/src/utils/identityMatcher.js
+++ b/src/utils/identityMatcher.js
@@ -35,7 +35,7 @@ function extractLinkedInUsername(data) {
   const usernamePattern = /\/in\/([a-zA-Z0-9_-]+)\/?/;
   const pidPattern = /^pid\.([a-zA-Z0-9_-]+)$/;
   // Pattern to detect Sales Nav IDs (should NOT be treated as usernames)
-  const salesNavIdPattern = /^A(Cw|Co)AAA/;
+  const salesNavIdPattern = /^A(Cw|Co)AA/;
 
   /**
    * Helper to validate extracted username

--- a/src/utils/identityResolver.js
+++ b/src/utils/identityResolver.js
@@ -12,7 +12,7 @@ const { parseLocation } = require("./location-parser");
  * while using the waterfall identity matching logic internally.
  *
  * Waterfall Priority (from identityMatcher.js):
- * 1. Sales Navigator ID (ACwAAA/ACoAAA) - MOST STABLE, never changes
+ * 1. Sales Navigator ID (ACwAA*/ACoAA*) - MOST STABLE, never changes
  * 2. LinkedIn Username - stable across Sales Nav + Regular LinkedIn
  * 3. Normalized Profile URL
  * 4. Public Profile / Recruiter Profile
@@ -24,11 +24,11 @@ const { parseLocation } = require("./location-parser");
 
 /**
  * Extract Sales Navigator person ID from URL or field
- * Format: ACwAAAxxxxxxx or ACoAAAxxxxxxx (base64-like ID)
+ * Format: ACwAAxxxxxxx or ACoAAxxxxxxx (base64-like ID)
  *
  * LinkedIn uses two formats:
  * - ACwAAA (common in scans): https://www.linkedin.com/sales/lead/ACwAAALwVAIBAlYW8bgTnsx7olXcSj4WBeNZygQ
- * - ACoAAA (common in visits): https://www.linkedin.com/sales/people/ACoAABJdcQ8BIhAujd1YYtK2saU-EJcfP4SRYuQ
+ * - ACoAAB (common in visits): https://www.linkedin.com/sales/people/ACoAABJdcQ8BIhAujd1YYtK2saU-EJcfP4SRYuQ
  *
  * @param {string} url - URL or field value
  * @returns {string|null} Sales Navigator person ID or null
@@ -36,9 +36,9 @@ const { parseLocation } = require("./location-parser");
 function extractSalesNavId(url) {
   if (!url || typeof url !== "string") return null;
 
-  // Pattern: Match BOTH ACwAAA and ACoAAA followed by base64-like characters
+  // Pattern: Match BOTH ACwAA and ACoAA prefixes followed by base64-like characters
   // Use explicit alternation to avoid character class ambiguity
-  const salesNavPattern = /((?:ACwAAA|ACoAAA)[A-Za-z0-9_-]+)/;
+  const salesNavPattern = /((?:ACwAA|ACoAA)[A-Za-z0-9_-]+)/;
   const match = url.match(salesNavPattern);
 
   return match ? match[1] : null;

--- a/src/utils/salesNavIdExtractor.js
+++ b/src/utils/salesNavIdExtractor.js
@@ -16,7 +16,7 @@
 /**
  * Extract Sales Navigator ID from any LinkedIn URL
  *
- * Pattern: ACwAAA or ACoAAA followed by alphanumeric chars, hyphens, underscores
+ * Pattern: ACwAA/ACoAA followed by alphanumeric chars, hyphens, underscores
  * Case-insensitive to handle lowercase IDs in URLs
  * Strips trailing parameters (,name,o7fk or ,NAME_SEARCH,Z1JY)
  *
@@ -38,9 +38,9 @@ function extractSalesNavIdFromUrl(url) {
     return null;
   }
 
-  // Pattern: A(Cw|Co)AAA followed by base64-like characters
-  // /i flag makes it case-insensitive (matches ACwAAA, acwaaa, AcWaAa, etc.)
-  const salesNavPattern = /A(Cw|Co)AAA[A-Za-z0-9_-]+/i;
+  // Pattern: A(Cw|Co)AA followed by base64-like characters
+  // /i flag makes it case-insensitive (matches ACwAAA, ACoAAB, acwaaa, etc.)
+  const salesNavPattern = /A(Cw|Co)AA[A-Za-z0-9_-]+/i;
 
   // Extract the ID using regex
   const match = url.match(salesNavPattern);
@@ -133,36 +133,38 @@ function extractSalesNavId(data) {
 /**
  * Normalize Sales Navigator ID to canonical case format
  *
- * LinkedIn's canonical format uses mixed case: ACwAAA or ACoAAA
- * URLs may contain lowercase versions: acwaaa or acoaaa
+ * LinkedIn's canonical format uses mixed case: ACwAAA/ACoAAA (and variants like ACwAAB)
+ * URLs may contain lowercase versions: acwaaa, acoaab, etc.
  *
  * This function normalizes to the canonical format for consistency.
  *
  * @param {string} salesNavId - Sales Navigator ID (any case)
- * @returns {string} - Normalized to canonical case (ACwAAA/ACoAAA prefix)
+ * @returns {string} - Normalized to canonical case (ACwAA/ACoAA prefix)
  *
  * @example
  * normalizeToCanonicalCase('acwaaa0cm4mb123')
  * // Returns: 'ACwAAA0cm4mb123'
  *
- * normalizeToCanonicalCase('ACoAAA123xyz')
- * // Returns: 'ACoAAA123xyz'
+ * normalizeToCanonicalCase('ACoAAB123xyz')
+ * // Returns: 'ACoAAB123xyz'
  */
 function normalizeToCanonicalCase(salesNavId) {
   if (!salesNavId || typeof salesNavId !== 'string') {
     return salesNavId;
   }
 
-  // Check if it starts with ACwAAA (case-insensitive)
-  if (salesNavId.toLowerCase().startsWith('acwaaa')) {
-    // Normalize to ACwAAA + rest of ID
-    return 'ACwAAA' + salesNavId.substring(6);
+  const lower = salesNavId.toLowerCase();
+
+  // Check if it starts with ACwAA (case-insensitive)
+  if (lower.startsWith('acwaa')) {
+    const sixthChar = salesNavId[5] ? salesNavId[5].toUpperCase() : '';
+    return `ACwAA${sixthChar}${salesNavId.substring(6)}`;
   }
 
-  // Check if it starts with ACoAAA (case-insensitive)
-  if (salesNavId.toLowerCase().startsWith('acoaaa')) {
-    // Normalize to ACoAAA + rest of ID
-    return 'ACoAAA' + salesNavId.substring(6);
+  // Check if it starts with ACoAA (case-insensitive)
+  if (lower.startsWith('acoaa')) {
+    const sixthChar = salesNavId[5] ? salesNavId[5].toUpperCase() : '';
+    return `ACoAA${sixthChar}${salesNavId.substring(6)}`;
   }
 
   // Already in canonical format or unknown format


### PR DESCRIPTION
### Motivation
- Some incoming observations use newer/variant Sales Navigator prefixes (e.g. `ACoAAB...`) so URLs were not being recognized and records fell back to `duxsoupId` as the primary anchor.
- The change ensures Sales Navigator IDs extracted from `salesUrl`/`recruiterUrl`/`profileUrl` take precedence as intended by the identity resolution priority.

### Description
- Expanded the SalesNav extraction pattern and normalization to accept the broader `ACwAA`/`ACoAA` prefix family and properly canonicalize the sixth character (see `src/utils/salesNavIdExtractor.js`).
- Updated the centralized matcher/resolver heuristics and regexes to treat `ACwAA`/`ACoAA` prefixed `_id`s as Sales Navigator IDs (changes in `src/utils/identityMatcher.js`, `src/utils/identityResolver.js`, and `src/services/identityResolverService.js`).
- Adjusted coverage counting to include the extended prefixes when computing Sales Nav coverage (change in `src/controllers/healthController.js`).
- Added/updated unit tests to cover `ACoAAB`/variant URL patterns and canonicalization (changes in `src/__tests__/salesNavIdExtractor.test.js`).

### Testing
- Ran the unit test file `npm test -- src/__tests__/salesNavIdExtractor.test.js` which executed the SalesNav extractor/normalization tests.
- All tests in that suite passed: `52 passed, 52 total`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a4595e0f483328524668e98558a87)