### PR TITLE
Inline salesNavId duplicate extraction in identity resolver service

### DIFF
--- a/src/__tests__/identityResolverService.integration.test.js
+++ b/src/__tests__/identityResolverService.integration.test.js
@@ -453,4 +453,64 @@ describe('IdentityResolverService', () => {
       expect(mergeRecord.loser_ids).toContain('12345678');
     });
   });
+
+  describe('findSalesNavIdDuplicates()', () => {
+    it('finds duplicates using extracted salesNavId and ignores unique records', async () => {
+      await Person.create({
+        _id: 'ACwAAA111',
+        canonical_id: canonicalIdFor('salesNavId', 'ACwAAA111'),
+        aliases: [{ type: 'salesNavId', value: 'ACwAAA111' }],
+        snapshot: {},
+        observations: { visits: [], scans: [] },
+      });
+
+      await Person.create({
+        _id: 'linkedin.com/in/jane-doe',
+        canonical_id: canonicalIdFor('publicUrl', 'linkedin.com/in/jane-doe'),
+        aliases: [
+          {
+            type: 'salesUrl',
+            value: 'www.linkedin.com/sales/lead/acwaaa111,NAME_SEARCH,Z1JY',
+          },
+        ],
+        snapshot: {},
+        observations: { visits: [], scans: [] },
+      });
+
+      await Person.create({
+        _id: 'linkedin.com/in/john-doe',
+        canonical_id: canonicalIdFor('publicUrl', 'linkedin.com/in/john-doe'),
+        aliases: [
+          { type: 'publicUrl', value: 'www.linkedin.com/in/ACwAAA111' },
+        ],
+        snapshot: {},
+        observations: { visits: [], scans: [] },
+      });
+
+      await Person.create({
+        _id: '12345678',
+        canonical_id: canonicalIdFor('numericId', '12345678'),
+        aliases: [{ type: 'numericId', value: '12345678' }],
+        snapshot: {},
+        observations: { visits: [], scans: [] },
+      });
+
+      const duplicates = await identityResolverService.findSalesNavIdDuplicates();
+      const groupsById = Object.fromEntries(
+        duplicates.map(group => [group.salesNavId, group.people])
+      );
+
+      expect(Object.keys(groupsById)).toEqual(['ACwAAA111']);
+      expect(groupsById.ACwAAA111).toHaveLength(3);
+
+      const duplicateIds = groupsById.ACwAAA111.map(person => person._id);
+      expect(duplicateIds).toEqual(
+        expect.arrayContaining([
+          'ACwAAA111',
+          'linkedin.com/in/jane-doe',
+          'linkedin.com/in/john-doe',
+        ])
+      );
+    });
+  });
 });

--- a/src/services/identityResolverService.js
+++ b/src/services/identityResolverService.js
@@ -1,5 +1,6 @@
 const Person = require('../models/person');
 const { computeCanonicalId, buildCanonicalKey } = require('../utils/identityResolver');
+const { extractSalesNavId, normalizeToCanonicalCase } = require('../utils/salesNavIdExtractor');
 const logger = require('../utils/logger');
 
 /**
@@ -534,6 +535,96 @@ class IdentityResolverService {
       throw error;
     }
   }
+
+  /**
+   * Find duplicate people grouped by salesNavId across the collection.
+   * Uses the same Sales Navigator extraction logic as identityMatcher/salesNavIdExtractor.
+   *
+   * @returns {Promise<Array<{salesNavId: string, people: Array<Object>}>>}
+   */
+  async findSalesNavIdDuplicates() {
+    const people = await Person.find({}, { _id: 1, aliases: 1 }).lean();
+    const grouped = new Map();
+
+    for (const person of people) {
+      const salesNavId = extractSalesNavIdFromPersonRecord(person);
+      if (!salesNavId) {
+        continue;
+      }
+
+      const existing = grouped.get(salesNavId) || [];
+      existing.push(person);
+      grouped.set(salesNavId, existing);
+    }
+
+    const duplicates = [];
+    for (const [salesNavId, matches] of grouped.entries()) {
+      if (matches.length > 1) {
+        duplicates.push({ salesNavId, people: matches });
+      }
+    }
+
+    return duplicates;
+  }
+}
+
+const SALES_NAV_ID_PATTERN = /^AC[wo]AA[A-Za-z0-9_-]+$/i;
+
+function extractSalesNavIdFromPersonRecord(person) {
+  if (!person) {
+    return null;
+  }
+
+  if (person._id && SALES_NAV_ID_PATTERN.test(person._id)) {
+    return normalizeToCanonicalCase(person._id);
+  }
+
+  const aliases = person.aliases || [];
+  const explicitAlias = aliases.find(
+    (alias) => alias?.type === 'salesNavId' && alias?.value,
+  );
+
+  if (explicitAlias) {
+    return normalizeToCanonicalCase(explicitAlias.value);
+  }
+
+  const data = buildSalesNavExtractionData(aliases);
+  const extracted = extractSalesNavId(data);
+
+  if (!extracted) {
+    return null;
+  }
+
+  return normalizeToCanonicalCase(extracted);
+}
+
+function buildSalesNavExtractionData(aliases = []) {
+  const data = {};
+
+  aliases.forEach((alias) => {
+    if (!alias?.value) {
+      return;
+    }
+
+    switch (alias.type) {
+      case 'salesUrl':
+        data.salesUrl = alias.value;
+        break;
+      case 'recruiterUrl':
+        data.recruiterUrl = alias.value;
+        break;
+      case 'profileUrl':
+        data.profileUrl = alias.value;
+        break;
+      case 'publicUrl':
+        data.PublicProfile = alias.value;
+        break;
+      default:
+        break;
+    }
+  });
+
+  return data;
 }
 
 module.exports = new IdentityResolverService();


### PR DESCRIPTION
### Motivation
- Keep Sales Navigator ID extraction colocated with duplicate-detection logic so duplicate grouping uses the same extraction behavior and reduce an extra helper module.
- Make `findSalesNavIdDuplicates()` self-contained and robust to IDs appearing in `_id` or in various alias URL fields.

### Description
- Inlined extraction helpers into `src/services/identityResolverService.js` by adding `extractSalesNavIdFromPersonRecord` and `buildSalesNavExtractionData` and by using `extractSalesNavId` and `normalizeToCanonicalCase` from `src/utils/salesNavIdExtractor`.
- Updated `findSalesNavIdDuplicates()` to use the inlined extractor and to group people by the canonical Sales Nav ID before returning duplicate groups.
- Removed the now-unused helper file `src/utils/peopleIdentity.js`.
- Adjusted the integration test `src/__tests__/identityResolverService.integration.test.js` to group duplicate results by `salesNavId` for clearer assertions in the `findSalesNavIdDuplicates()` test.

### Testing
- No automated test suite was executed as part of this change.
- The integration test `findSalesNavIdDuplicates()` in `src/__tests__/identityResolverService.integration.test.js` was updated but not run automatically in this rollout.
- A commit was created including the code and test updates; CI or local `npm run test:integration` can be used to run the updated integration test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a4f092b9c8332bd5683bab8bb0927)