### PR TITLE
Specify npm version in packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,6 @@
   },
   "engines": {
     "node": ">=18.0.0"
-  }
+  },
+  "packageManager": "npm@10.8.2"
 }


### PR DESCRIPTION
## Summary
This change pins the npm package manager version to 10.8.2 by adding the `packageManager` field to package.json.

## Key Changes
- Added `packageManager: "npm@10.8.2"` to package.json
- This ensures all developers and CI/CD environments use a consistent npm version

## Implementation Details
The `packageManager` field is a standard npm feature (supported in npm 8.9.0+) that enforces a specific package manager version. When set, npm will warn users if they attempt to install dependencies with a different version. This improves consistency across development environments and reduces "works on my machine" issues related to package manager version differences.

https://claude.ai/code/session_01U1vPF697Lj2peqoWLFjC9v