### PR TITLE
Improve CORS security with restrictive default configuration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,9 +18,17 @@ try {
 const config = getConfig();
 const app = express();
 
-// Security and middleware configuration
+// CORS configuration - restrictive by default
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',').map(o => o.trim())
+  : false; // Reject all cross-origin requests when not configured
+
+if (!process.env.ALLOWED_ORIGINS) {
+  logger.warn('ALLOWED_ORIGINS not set - CORS will reject all cross-origin browser requests. Server-to-server webhooks are unaffected.');
+}
+
 app.use(cors({
-  origin: process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(',') : '*',
+  origin: allowedOrigins,
   methods: ['GET', 'POST'],
   allowedHeaders: ['Content-Type', 'Authorization']
 }));


### PR DESCRIPTION
## Summary
This change improves the security posture of the application by making CORS configuration more restrictive by default. Instead of allowing all cross-origin requests when `ALLOWED_ORIGINS` is not configured, the application now rejects all cross-origin browser requests unless explicitly allowed.

## Key Changes
- Changed CORS default from permissive (`'*'`) to restrictive (`false`) when `ALLOWED_ORIGINS` environment variable is not set
- Added warning log message to alert operators when CORS is not configured, clarifying that server-to-server webhooks are unaffected
- Refactored CORS origin configuration into a separate variable for improved readability and maintainability

## Implementation Details
- When `ALLOWED_ORIGINS` is not set, `allowedOrigins` is set to `false`, which causes the CORS middleware to reject all cross-origin requests
- The warning message helps operators understand the security implications and guides them to configure `ALLOWED_ORIGINS` if needed
- Server-to-server webhook communication remains unaffected since it doesn't rely on browser CORS policies
- The comma-separated parsing of `ALLOWED_ORIGINS` is preserved for backward compatibility with existing configurations

https://claude.ai/code/session_01L2faRrhBwK7niZqg9u2cLA