### PR TITLE
Add Atlas Search index configuration and management script

### DIFF
--- a/docs/production-setup.md
+++ b/docs/production-setup.md
@@ -136,6 +136,46 @@ The system looks for the MongoDB URI in this order:
 | `PORT`        | `3000`        | `3000`             | API server port     |
 | `LOG_LEVEL`   | `debug`       | `info`             | Logging verbosity   |
 
+## Atlas Search Index Configuration
+
+The `people` collection supports MongoDB Atlas Search for advanced full-text search capabilities.
+
+### Field Limit Issue
+
+Atlas Search indexes have a **300 field limit**. The default dynamic mapping will fail because:
+- The `snapshot._meta` field (Mixed type) stores provenance metadata for every field
+- Array fields like `roles[]` and `education[]` multiply field counts
+- Total fields with dynamic mapping: **309+** (exceeds limit)
+
+### Fix: Use Static Field Mapping
+
+Run the helper script to get the correct index definition:
+
+```bash
+node scripts/createAtlasSearchIndex.js --output
+```
+
+Then apply via Atlas UI:
+
+1. Go to **Atlas UI > Database > Browse Collections > Search**
+2. Delete the failing "default" index on "people" collection
+3. Click **Create Search Index**
+4. Select **JSON Editor**
+5. Paste the definition from the script output
+6. Index Name: `default`, Collection: `people`
+7. Click **Create Search Index**
+
+The static mapping indexes only **13 searchable fields** instead of 309+:
+- `snapshot.fullName`, `firstName`, `lastName`
+- `snapshot.currentTitle`, `currentCompany`
+- `snapshot.industry`, `location`, `city`, `state`, `country`
+- `snapshot.summary`, `skills`, `email`
+- `aliases.value` (for ID lookups)
+
+### Note on Search Implementation
+
+The application currently uses MongoDB's native `$text` search (defined in `src/models/person.js`), which works independently of Atlas Search. The Atlas Search index is optional and provides additional features like fuzzy matching and autocomplete if needed in the future.
+
 ## Troubleshooting
 
 ### Wrong Database Connected

--- a/scripts/atlas-search-indexes.json
+++ b/scripts/atlas-search-indexes.json
@@ -1,0 +1,85 @@
+{
+  "$comment": "Atlas Search Index Definitions for duxsoup database. Apply via Atlas UI or mongocli.",
+  "indexes": [
+    {
+      "name": "default",
+      "collectionName": "people",
+      "database": "duxsoup",
+      "type": "search",
+      "definition": {
+        "mappings": {
+          "dynamic": false,
+          "fields": {
+            "snapshot": {
+              "type": "document",
+              "fields": {
+                "fullName": {
+                  "type": "string",
+                  "analyzer": "lucene.standard"
+                },
+                "firstName": {
+                  "type": "string",
+                  "analyzer": "lucene.standard"
+                },
+                "lastName": {
+                  "type": "string",
+                  "analyzer": "lucene.standard"
+                },
+                "currentTitle": {
+                  "type": "string",
+                  "analyzer": "lucene.standard"
+                },
+                "currentCompany": {
+                  "type": "string",
+                  "analyzer": "lucene.standard"
+                },
+                "industry": {
+                  "type": "string",
+                  "analyzer": "lucene.standard"
+                },
+                "location": {
+                  "type": "string",
+                  "analyzer": "lucene.standard"
+                },
+                "city": {
+                  "type": "string",
+                  "analyzer": "lucene.standard"
+                },
+                "state": {
+                  "type": "string",
+                  "analyzer": "lucene.standard"
+                },
+                "country": {
+                  "type": "string",
+                  "analyzer": "lucene.standard"
+                },
+                "summary": {
+                  "type": "string",
+                  "analyzer": "lucene.standard"
+                },
+                "skills": {
+                  "type": "string",
+                  "analyzer": "lucene.standard"
+                },
+                "email": {
+                  "type": "string",
+                  "analyzer": "lucene.keyword"
+                }
+              }
+            },
+            "aliases": {
+              "type": "document",
+              "fields": {
+                "value": {
+                  "type": "string",
+                  "analyzer": "lucene.keyword"
+                }
+              }
+            }
+          }
+        },
+        "analyzer": "lucene.standard"
+      }
+    }
+  ]
+}

--- a/scripts/createAtlasSearchIndex.js
+++ b/scripts/createAtlasSearchIndex.js
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+
+/**
+ * Atlas Search Index Management Script
+ *
+ * Creates or updates Atlas Search indexes with static field mappings
+ * to avoid the 300-field limit when using dynamic mapping.
+ *
+ * Problem: Dynamic mapping indexes ALL fields including:
+ *   - snapshot._meta (Mixed type with ~35+ nested keys)
+ *   - roles[] array (8 fields × N entries)
+ *   - education[] array (5 fields × N entries)
+ *   This causes: "Field limit exceeded: 309 > 300"
+ *
+ * Solution: Static mapping indexes only searchable fields (13 fields)
+ *
+ * Usage:
+ *   # View current search indexes
+ *   node scripts/createAtlasSearchIndex.js --list
+ *
+ *   # Output index definition for manual creation
+ *   node scripts/createAtlasSearchIndex.js --output
+ *
+ *   # Create index via Atlas Admin API (requires ATLAS_* env vars)
+ *   node scripts/createAtlasSearchIndex.js --create
+ *
+ * Environment variables (for --create):
+ *   ATLAS_PROJECT_ID  - Atlas Project ID
+ *   ATLAS_CLUSTER     - Cluster name (e.g., "Cluster0")
+ *   ATLAS_PUBLIC_KEY  - Atlas API public key
+ *   ATLAS_PRIVATE_KEY - Atlas API private key
+ */
+
+const mongoose = require('mongoose');
+const https = require('https');
+const logger = require('../src/utils/logger');
+const indexDefinitions = require('./atlas-search-indexes.json');
+
+const ATLAS_API_BASE = 'cloud.mongodb.com/api/atlas/v1.0';
+
+async function listSearchIndexes() {
+  console.log('📋 Listing current search indexes...\n');
+
+  const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/duxsoup-etl';
+  await mongoose.connect(mongoUri);
+  console.log('✓ Connected to MongoDB\n');
+
+  const db = mongoose.connection.db;
+
+  // List indexes on people collection
+  const peopleCollection = db.collection('people');
+
+  try {
+    // Get regular indexes
+    const indexes = await peopleCollection.indexes();
+    console.log('Regular indexes on people collection:');
+    indexes.forEach((idx) => {
+      const keys = Object.keys(idx.key)
+        .map((k) => `${k}: ${idx.key[k]}`)
+        .join(', ');
+      console.log(`  - ${idx.name}: { ${keys} }`);
+    });
+
+    // Note: Atlas Search indexes are managed separately via Atlas API
+    console.log('\n⚠️  Atlas Search indexes cannot be listed via MongoDB driver.');
+    console.log('   Use Atlas UI or mongocli to view search indexes.');
+    console.log('\n   Atlas UI: https://cloud.mongodb.com/');
+    console.log('   mongocli: mongocli atlas clusters search indexes list');
+  } catch (error) {
+    console.error('Error listing indexes:', error.message);
+  }
+
+  await mongoose.connection.close();
+}
+
+function outputIndexDefinition() {
+  console.log('📄 Atlas Search Index Definition\n');
+  console.log('Copy this JSON and paste it in Atlas UI > Search > Create Index > JSON Editor:\n');
+  console.log('─'.repeat(70));
+
+  const peopleIndex = indexDefinitions.indexes.find(
+    (idx) => idx.collectionName === 'people'
+  );
+
+  if (peopleIndex) {
+    console.log(JSON.stringify(peopleIndex.definition, null, 2));
+  }
+
+  console.log('─'.repeat(70));
+  console.log('\nSteps to apply:');
+  console.log('1. Go to Atlas UI > Database > Browse Collections > Search');
+  console.log('2. Delete the failing "default" index on "people" collection');
+  console.log('3. Click "Create Search Index"');
+  console.log('4. Select "JSON Editor"');
+  console.log('5. Paste the definition above');
+  console.log('6. Index Name: "default"');
+  console.log('7. Collection: "people"');
+  console.log('8. Click "Create Search Index"');
+  console.log('\nThe index will build in the background (usually < 5 minutes).\n');
+}
+
+async function createViaAtlasAPI() {
+  const { ATLAS_PROJECT_ID, ATLAS_CLUSTER, ATLAS_PUBLIC_KEY, ATLAS_PRIVATE_KEY } =
+    process.env;
+
+  if (!ATLAS_PROJECT_ID || !ATLAS_CLUSTER || !ATLAS_PUBLIC_KEY || !ATLAS_PRIVATE_KEY) {
+    console.error('❌ Missing required environment variables:');
+    console.error('   ATLAS_PROJECT_ID, ATLAS_CLUSTER, ATLAS_PUBLIC_KEY, ATLAS_PRIVATE_KEY');
+    console.error('\nUse --output to get the index definition for manual creation.');
+    process.exit(1);
+  }
+
+  console.log('🚀 Creating Atlas Search index via API...\n');
+
+  const peopleIndex = indexDefinitions.indexes.find(
+    (idx) => idx.collectionName === 'people'
+  );
+
+  const requestBody = JSON.stringify({
+    collectionName: peopleIndex.collectionName,
+    database: peopleIndex.database,
+    name: peopleIndex.name,
+    mappings: peopleIndex.definition.mappings,
+  });
+
+  const auth = Buffer.from(`${ATLAS_PUBLIC_KEY}:${ATLAS_PRIVATE_KEY}`).toString('base64');
+
+  const options = {
+    hostname: ATLAS_API_BASE.split('/')[0],
+    path: `/api/atlas/v1.0/groups/${ATLAS_PROJECT_ID}/clusters/${ATLAS_CLUSTER}/fts/indexes`,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': requestBody.length,
+      Authorization: `Basic ${auth}`,
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          console.log('✅ Search index created successfully!');
+          console.log('   Index will build in the background.\n');
+          resolve(JSON.parse(data));
+        } else {
+          console.error(`❌ API Error (${res.statusCode}):`, data);
+          reject(new Error(data));
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.write(requestBody);
+    req.end();
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--list') || args.includes('-l')) {
+    await listSearchIndexes();
+  } else if (args.includes('--output') || args.includes('-o')) {
+    outputIndexDefinition();
+  } else if (args.includes('--create') || args.includes('-c')) {
+    await createViaAtlasAPI();
+  } else {
+    console.log('Atlas Search Index Management\n');
+    console.log('Usage:');
+    console.log('  --list, -l     List current indexes (regular only)');
+    console.log('  --output, -o   Output index definition for manual creation');
+    console.log('  --create, -c   Create index via Atlas Admin API\n');
+    console.log('Recommended: Use --output and apply via Atlas UI\n');
+
+    // Default to output
+    outputIndexDefinition();
+  }
+}
+
+main().catch((error) => {
+  logger.error('Script failed', { error: error.message });
+  console.error('Error:', error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds documentation and tooling for configuring MongoDB Atlas Search indexes on the `people` collection with static field mappings to work around the 300-field limit imposed by Atlas Search.

## Problem
The default dynamic mapping for Atlas Search fails because:
- The `snapshot._meta` field stores provenance metadata for every field
- Array fields like `roles[]` and `education[]` multiply field counts
- Total fields exceed the 300-field limit (309+)

## Solution
Implements a static field mapping that indexes only 13 searchable fields instead of 309+, avoiding the field limit issue.

## Changes Made
- **docs/production-setup.md**: Added comprehensive "Atlas Search Index Configuration" section explaining:
  - The field limit issue and why it occurs
  - Step-by-step instructions for applying the index via Atlas UI
  - List of indexed fields
  - Note that the app currently uses native `$text` search independently
  
- **scripts/atlas-search-indexes.json**: New file containing the static field mapping index definition for the `people` collection with 13 searchable fields

- **scripts/createAtlasSearchIndex.js**: New helper script with multiple modes:
  - `--list`: List regular MongoDB indexes
  - `--output`: Display the index definition for manual creation via Atlas UI (recommended)
  - `--create`: Create index via Atlas Admin API (requires credentials)

## Implementation Details
- The static mapping includes essential fields: name, title, company, industry, location, summary, skills, email, and aliases
- Uses `lucene.standard` analyzer for most fields and `lucene.keyword` for email and aliases
- Script includes detailed comments explaining the problem and solution
- Documentation emphasizes that Atlas Search is optional; the app uses native `$text` search which works independently

https://claude.ai/code/session_01Rb1SUQBbvbwkFQp9c2bZBs