### PR TITLE
Add MongoDB Atlas security hardening guide to production docs

### DIFF
--- a/docs/production-setup.md
+++ b/docs/production-setup.md
@@ -36,9 +36,51 @@ LOG_LEVEL=info
 
 - [ ] Update `MONGODB_URI` with production database credentials
 - [ ] Ensure MongoDB has proper authentication enabled
-- [ ] Configure `CORS_ORIGIN` if needed for API access
+- [ ] **Restrict MongoDB Atlas IP Access List** (see below)
+- [ ] Configure `ALLOWED_ORIGINS` for CORS restrictions
 - [ ] Review and set appropriate `LOG_LEVEL` (info, warn, error)
 - [ ] Backup your database before running migrations
+
+### 3. MongoDB Atlas Network Access (Critical)
+
+**Never use `0.0.0.0/0` in production.** This allows connections from any IP worldwide.
+
+#### For Render Deployments
+
+Render uses dynamic outbound IPs on the free plan. Options:
+
+**Option A: Upgrade to Render Paid Plan (Recommended)**
+1. Upgrade to a paid Render plan to get static outbound IPs
+2. Go to Render Dashboard → Service → "Outbound IPs"
+3. In MongoDB Atlas: Security → Network Access → Add IP Address
+4. Add only the Render outbound IPs
+
+**Option B: Use MongoDB Atlas Private Endpoints**
+For M10+ clusters, configure AWS/GCP PrivateLink for zero-exposure networking.
+
+**Option C: Temporary Development Access**
+If you must allow broad access temporarily:
+1. Use the narrowest CIDR range possible
+2. Set an expiration date in Atlas (e.g., 24 hours)
+3. Remove immediately after development session
+
+#### To Restrict Access in Atlas
+
+1. Log into [MongoDB Atlas](https://cloud.mongodb.com/)
+2. Go to **Security → Network Access**
+3. **Delete** the `0.0.0.0/0` entry
+4. **Delete** any overly broad CIDR ranges (e.g., `/16` blocks)
+5. **Add** only specific IPs:
+   - Your Render service outbound IPs
+   - Your development machine IP (with expiration)
+   - CI/CD runner IPs if needed
+
+#### Verifying Current Access
+
+Check your Atlas IP Access List for these red flags:
+- `0.0.0.0/0` - Allows entire internet
+- `/8`, `/16` CIDR ranges - Millions of IPs
+- No expiration dates on temporary entries
 
 ## Running Migrations in Production
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive security guidance for MongoDB Atlas network access configuration in production deployments, with specific recommendations for Render hosting environments.

## Key Changes
- Added new "MongoDB Atlas Network Access (Critical)" section to production setup documentation
- Documented the security risks of using `0.0.0.0/0` CIDR range in production
- Provided three implementation options for securing MongoDB Atlas access:
  - **Option A**: Upgrade to Render paid plan for static outbound IPs (recommended)
  - **Option B**: Use MongoDB Atlas Private Endpoints for zero-exposure networking
  - **Option C**: Temporary broad access with expiration dates (development only)
- Added step-by-step instructions for restricting IP access in MongoDB Atlas console
- Included verification checklist to identify common security misconfigurations
- Updated checklist item from `CORS_ORIGIN` to `ALLOWED_ORIGINS` for consistency

## Implementation Details
- The new section is positioned early in the setup checklist (item 3) to emphasize its critical importance
- Includes specific warnings about dangerous CIDR ranges (`/8`, `/16` blocks)
- Provides actionable steps for both initial setup and ongoing verification
- Tailored guidance for Render's dynamic IP limitations on free tier
- Emphasizes principle of least privilege with specific IP allowlisting

## Security Impact
This change significantly improves the security posture of production deployments by preventing accidental exposure of MongoDB instances to the entire internet, which is a common misconfiguration in early-stage deployments.

https://claude.ai/code/session_01D8t5DkQDQ3KR7hTgiLELVB