### PR TITLE
Improve identity normalization and add dedupe/backfill tooling

### DIFF
--- a/scripts/backfill-alias-normalization.js
+++ b/scripts/backfill-alias-normalization.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+/**
+ * Backfill alias normalization for existing people records.
+ *
+ * Adds normalized aliases without changing canonical IDs.
+ *
+ * Usage:
+ *   node scripts/backfill-alias-normalization.js --dry-run
+ *   node scripts/backfill-alias-normalization.js --execute
+ *   node scripts/backfill-alias-normalization.js --execute --limit=1000 --batch-size=200
+ */
+
+const mongoose = require('mongoose');
+require('dotenv').config();
+
+const Person = require('../src/models/person');
+const logger = require('../src/utils/logger');
+const identityMatcher = require('../src/utils/identityMatcher');
+const {
+  extractSalesNavIdFromUrl,
+  normalizeToCanonicalCase,
+  extractNumericId,
+} = require('../src/utils/salesNavIdExtractor');
+
+const args = process.argv.slice(2);
+const isExecute = args.includes('--execute');
+const isDryRun = args.includes('--dry-run') || !isExecute;
+
+const limitArg = args.find(arg => arg.startsWith('--limit='));
+const limit = limitArg ? parseInt(limitArg.split('=')[1], 10) : null;
+
+const batchArg = args.find(arg => arg.startsWith('--batch-size='));
+const batchSize = batchArg ? parseInt(batchArg.split('=')[1], 10) : 250;
+
+function normalizeValue(value) {
+  return value ? value.toString().trim().toLowerCase() : null;
+}
+
+function extractUsernameFromUrl(url) {
+  if (!url) return null;
+  const normalized = identityMatcher.normalizeUrl(url);
+  if (!normalized) return null;
+  const match = normalized.match(/linkedin\.com\/in\/([^\/\?]+)/);
+  if (!match) return null;
+  return match[1].toLowerCase();
+}
+
+function buildAliasMap(aliases = []) {
+  const map = new Map();
+  aliases.forEach(alias => {
+    if (!alias?.type || !alias?.value) return;
+    map.set(`${alias.type}:${alias.value}`, alias.value);
+  });
+  return map;
+}
+
+function addAlias(aliasesToAdd, existingMap, type, value) {
+  if (!value) return;
+  const key = `${type}:${value}`;
+  if (existingMap.has(key)) return;
+  existingMap.set(key, value);
+  aliasesToAdd.push({ type, value });
+}
+
+async function run() {
+  const mongoUri = process.env.MONGO_URI;
+  if (!mongoUri) {
+    throw new Error('MONGO_URI is not set');
+  }
+
+  await mongoose.connect(mongoUri, {
+    serverSelectionTimeoutMS: 30000,
+  });
+
+  logger.info('Connected to MongoDB');
+
+  const query = {};
+  if (limit) {
+    logger.info(`Limiting to ${limit} records`);
+  }
+
+  const cursor = Person.find(query).cursor();
+
+  let processed = 0;
+  let updated = 0;
+  let totalAliasesAdded = 0;
+
+  const pendingUpdates = [];
+
+  for await (const person of cursor) {
+    if (limit && processed >= limit) {
+      break;
+    }
+
+    processed += 1;
+    const existingMap = buildAliasMap(person.aliases);
+    const aliasesToAdd = [];
+
+    const allAliasValues = (person.aliases || [])
+      .map(alias => alias?.value)
+      .filter(Boolean);
+
+    allAliasValues.forEach(value => {
+      const normalizedUrl = identityMatcher.normalizeUrl(value);
+      if (normalizedUrl && normalizedUrl !== value) {
+        addAlias(aliasesToAdd, existingMap, 'profileUrl', normalizedUrl);
+      }
+
+      const publicUrl = identityMatcher.normalizePublicProfileUrl(value);
+      if (publicUrl) {
+        addAlias(aliasesToAdd, existingMap, 'publicUrl', publicUrl);
+      }
+
+      const username = extractUsernameFromUrl(value);
+      if (username) {
+        addAlias(aliasesToAdd, existingMap, 'linkedInUsername', username);
+      }
+
+      const salesNavId = extractSalesNavIdFromUrl(value);
+      if (salesNavId) {
+        addAlias(
+          aliasesToAdd,
+          existingMap,
+          'salesNavId',
+          normalizeToCanonicalCase(salesNavId),
+        );
+      }
+    });
+
+    const duxsoupAlias = (person.aliases || []).find(
+      alias => alias?.type === 'duxsoupId' && alias?.value,
+    );
+
+    if (duxsoupAlias?.value) {
+      const normalizedDuxsoup = identityMatcher.normalizeDuxsoupId(
+        duxsoupAlias.value,
+      );
+      if (normalizedDuxsoup && normalizedDuxsoup !== duxsoupAlias.value) {
+        addAlias(aliasesToAdd, existingMap, 'duxsoupId', normalizedDuxsoup);
+      }
+
+      const numericId = extractNumericId(duxsoupAlias.value);
+      if (numericId) {
+        addAlias(aliasesToAdd, existingMap, 'numericId', numericId);
+      }
+    }
+
+    const salesNavAlias = (person.aliases || []).find(
+      alias => alias?.type === 'salesNavId' && alias?.value,
+    );
+    if (salesNavAlias?.value) {
+      const canonical = normalizeToCanonicalCase(salesNavAlias.value);
+      if (canonical && canonical !== salesNavAlias.value) {
+        addAlias(aliasesToAdd, existingMap, 'salesNavId', canonical);
+      }
+    }
+
+    if (aliasesToAdd.length > 0) {
+      updated += 1;
+      totalAliasesAdded += aliasesToAdd.length;
+
+      if (!isDryRun) {
+        pendingUpdates.push({
+          updateOne: {
+            filter: { _id: person._id },
+            update: { $addToSet: { aliases: { $each: aliasesToAdd } } },
+          },
+        });
+      }
+    }
+
+    if (!isDryRun && pendingUpdates.length >= batchSize) {
+      await Person.bulkWrite(pendingUpdates);
+      pendingUpdates.length = 0;
+    }
+  }
+
+  if (!isDryRun && pendingUpdates.length > 0) {
+    await Person.bulkWrite(pendingUpdates);
+  }
+
+  logger.info('Alias normalization backfill complete', {
+    processed,
+    updated,
+    totalAliasesAdded,
+    mode: isDryRun ? 'dry-run' : 'execute',
+  });
+
+  await mongoose.disconnect();
+}
+
+run().catch(error => {
+  logger.error('Alias normalization backfill failed', { error: error.message });
+  process.exit(1);
+});

--- a/scripts/merge-duplicates.js
+++ b/scripts/merge-duplicates.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+/**
+ * Merge duplicate people with high-confidence heuristics.
+ *
+ * Usage:
+ *   node scripts/merge-duplicates.js --dry-run --output=merge-review.csv
+ *   node scripts/merge-duplicates.js --execute --limit-groups=100
+ */
+
+const fs = require('fs');
+const path = require('path');
+const mongoose = require('mongoose');
+require('dotenv').config();
+
+const Person = require('../src/models/person');
+const identityResolverService = require('../src/services/identityResolverService');
+const logger = require('../src/utils/logger');
+
+const args = process.argv.slice(2);
+const isExecute = args.includes('--execute');
+const isDryRun = args.includes('--dry-run') || !isExecute;
+
+const limitArg = args.find(arg => arg.startsWith('--limit-groups='));
+const limitGroups = limitArg ? parseInt(limitArg.split('=')[1], 10) : null;
+
+const outputArg = args.find(arg => arg.startsWith('--output='));
+const outputPath = outputArg
+  ? outputArg.split('=')[1]
+  : path.join(process.cwd(), 'merge-duplicates.csv');
+
+function normalizeValue(value) {
+  return value ? value.toString().trim().toLowerCase() : null;
+}
+
+function buildGroupKey(person) {
+  const name = normalizeValue(person.snapshot?.fullName);
+  const company = normalizeValue(person.snapshot?.currentCompany);
+  if (!name || !company) {
+    return null;
+  }
+
+  const location = normalizeValue(person.snapshot?.location);
+  const title = normalizeValue(person.snapshot?.currentTitle);
+
+  if (location) {
+    return `${name}|${company}|location:${location}`;
+  }
+
+  if (title) {
+    return `${name}|${company}|title:${title}`;
+  }
+
+  return null;
+}
+
+function formatCsvRow(values) {
+  return values
+    .map(value => {
+      const text = value === null || value === undefined ? '' : value.toString();
+      if (text.includes(',') || text.includes('"') || text.includes('\n')) {
+        return `"${text.replace(/"/g, '""')}"`;
+      }
+      return text;
+    })
+    .join(',');
+}
+
+async function run() {
+  const mongoUri = process.env.MONGO_URI;
+  if (!mongoUri) {
+    throw new Error('MONGO_URI is not set');
+  }
+
+  await mongoose.connect(mongoUri, {
+    serverSelectionTimeoutMS: 30000,
+  });
+
+  logger.info('Connected to MongoDB');
+
+  const cursor = Person.find(
+    {},
+    {
+      _id: 1,
+      canonical_id: 1,
+      aliases: 1,
+      snapshot: 1,
+      observations: 1,
+    },
+  ).cursor();
+
+  const grouped = new Map();
+
+  for await (const person of cursor) {
+    const key = buildGroupKey(person);
+    if (!key) {
+      continue;
+    }
+
+    const existing = grouped.get(key) || [];
+    existing.push(person);
+    grouped.set(key, existing);
+  }
+
+  const candidateGroups = Array.from(grouped.values()).filter(
+    group => group.length > 1,
+  );
+
+  logger.info('Found candidate groups', {
+    groups: candidateGroups.length,
+    dryRun: isDryRun,
+  });
+
+  let processedGroups = 0;
+  let mergedGroups = 0;
+  let mergedPeople = 0;
+
+  const csvRows = [
+    formatCsvRow([
+      'groupKey',
+      'fullName',
+      'currentCompany',
+      'location',
+      'currentTitle',
+      'personIds',
+      'canonicalIds',
+      'observationsCount',
+      'aliasCounts',
+    ]),
+  ];
+
+  for (const group of candidateGroups) {
+    if (limitGroups && processedGroups >= limitGroups) {
+      break;
+    }
+
+    processedGroups += 1;
+
+    const representative = group[0];
+    const groupKey = buildGroupKey(representative);
+
+    csvRows.push(
+      formatCsvRow([
+        groupKey,
+        representative.snapshot?.fullName || '',
+        representative.snapshot?.currentCompany || '',
+        representative.snapshot?.location || '',
+        representative.snapshot?.currentTitle || '',
+        group.map(person => person._id).join('|'),
+        group.map(person => person.canonical_id).join('|'),
+        group
+          .map(
+            person =>
+              (person.observations?.visits?.length || 0) +
+              (person.observations?.scans?.length || 0),
+          )
+          .join('|'),
+        group.map(person => person.aliases?.length || 0).join('|'),
+      ]),
+    );
+
+    if (isDryRun) {
+      continue;
+    }
+
+    const ids = group.map(person => person._id);
+    const people = await Person.find({ _id: { $in: ids } });
+
+    if (people.length < 2) {
+      continue;
+    }
+
+    const winner = identityResolverService.determineWinner(people);
+    const losers = people.filter(person => person._id !== winner._id);
+
+    await identityResolverService.mergePeople(winner, losers, {
+      reason: 'duplicate_detection',
+    });
+
+    mergedGroups += 1;
+    mergedPeople += losers.length;
+  }
+
+  if (isDryRun) {
+    fs.writeFileSync(outputPath, csvRows.join('\n'));
+  }
+
+  logger.info('Duplicate merge summary', {
+    processedGroups,
+    mergedGroups,
+    mergedPeople,
+    outputPath: isDryRun ? outputPath : null,
+    mode: isDryRun ? 'dry-run' : 'execute',
+  });
+
+  await mongoose.disconnect();
+}
+
+run().catch(error => {
+  logger.error('Duplicate merge failed', { error: error.message });
+  process.exit(1);
+});

--- a/src/__tests__/identityResolver.test.js
+++ b/src/__tests__/identityResolver.test.js
@@ -181,7 +181,7 @@ describe("Identity Resolution Utility", () => {
 
       const result = resolvePersonIdentity(webhookData);
 
-      expect(result.person_id).toBe("www.linkedin.com/profile/87654321");
+      expect(result.person_id).toBe("linkedin.com/profile/87654321");
       expect(result.source).toBe("profileUrl");
     });
 
@@ -214,6 +214,20 @@ describe("Identity Resolution Utility", () => {
       expect(result.aliases).toContainEqual(
         expect.objectContaining({ type: "linkedInUsername", value: "johndoe" }),
       );
+    });
+
+    it("should add numericId alias when duxsoup ID is numeric", () => {
+      const webhookData = {
+        id: "id.218248067",
+        Profile: "https://www.linkedin.com/profile/218248067",
+      };
+
+      const result = resolvePersonIdentity(webhookData);
+
+      expect(result.aliases).toContainEqual({
+        type: "numericId",
+        value: "218248067",
+      });
     });
 
     it("should compute canonical_id for sales nav identity", () => {

--- a/src/models/person.js
+++ b/src/models/person.js
@@ -241,6 +241,16 @@ const personSchema = new mongoose.Schema(
       avgTenureMonths: Number,
       yearsAtCurrentCompany: Number,
     },
+
+    // Merge tracking (optional audit metadata)
+    mergedInto: {
+      type: String,
+      default: null,
+    },
+    mergedAt: {
+      type: Date,
+      default: null,
+    },
   },
   {
     timestamps: true,

--- a/src/utils/identityMatcher.js
+++ b/src/utils/identityMatcher.js
@@ -60,7 +60,14 @@ function extractLinkedInUsername(data) {
     }
   }
 
-  // 2. Check Profile URL
+  // 2. Check explicit LinkedIn username field
+  const explicitUsername = data.LinkedInUsername || data.data?.LinkedInUsername;
+  if (explicitUsername) {
+    const username = validateUsername(explicitUsername);
+    if (username) return username;
+  }
+
+  // 3. Check Profile URL
   const profile = data.Profile || data.data?.Profile;
   if (profile) {
     const match = profile.match(usernamePattern);
@@ -70,7 +77,7 @@ function extractLinkedInUsername(data) {
     }
   }
 
-  // 3. Check PublicProfile
+  // 4. Check PublicProfile
   const publicProfile = data.PublicProfile || data.data?.PublicProfile;
   if (publicProfile) {
     const match = publicProfile.match(usernamePattern);
@@ -80,7 +87,7 @@ function extractLinkedInUsername(data) {
     }
   }
 
-  // 4. Check SalesProfile (rare, but possible)
+  // 5. Check SalesProfile (rare, but possible)
   const salesProfile = data.SalesProfile || data.data?.SalesProfile;
   if (salesProfile) {
     const match = salesProfile.match(usernamePattern);
@@ -90,7 +97,7 @@ function extractLinkedInUsername(data) {
     }
   }
 
-  // 5. Check RecruiterProfile
+  // 6. Check RecruiterProfile
   const recruiterProfile = data.RecruiterProfile || data.data?.RecruiterProfile;
   if (recruiterProfile) {
     const match = recruiterProfile.match(usernamePattern);
@@ -136,10 +143,48 @@ function normalizeUrl(url) {
     normalized = normalized.split("?")[0];
     // Remove http/https differences
     normalized = normalized.replace(/^https?:\/\//, "");
+    // Normalize www subdomain
+    normalized = normalized.replace(/^www\./, "");
     return normalized;
   } catch (e) {
     return url;
   }
+}
+
+/**
+ * Normalize public LinkedIn profile URLs to linkedin.com/in/<username> or linkedin.com/pub/<slug>
+ *
+ * @param {string} url - LinkedIn URL
+ * @returns {string|null} - Normalized public profile URL or null
+ */
+function normalizePublicProfileUrl(url) {
+  if (!url || typeof url !== 'string') return null;
+
+  const normalized = normalizeUrl(url);
+  if (!normalized) {
+    return null;
+  }
+
+  const match = normalized.match(/linkedin\.com\/(in|pub)\/([^\/\?]+)/);
+  if (!match) {
+    return null;
+  }
+
+  return `linkedin.com/${match[1]}/${match[2]}`;
+}
+
+/**
+ * Normalize DuxSoup IDs to a canonical lowercase format.
+ *
+ * @param {string} duxsoupId - DuxSoup ID
+ * @returns {string|null} - Normalized DuxSoup ID or null
+ */
+function normalizeDuxsoupId(duxsoupId) {
+  if (!duxsoupId || typeof duxsoupId !== 'string') {
+    return null;
+  }
+
+  return duxsoupId.trim().toLowerCase();
 }
 
 /**
@@ -154,15 +199,19 @@ function extractIdentifiers(data) {
   const { extractNumericId } = require('./salesNavIdExtractor');
 
   const duxsoupId = data.id || data.data?.id || null;
+  const normalizedDuxsoupId = normalizeDuxsoupId(duxsoupId);
   const numericId = duxsoupId ? extractNumericId(duxsoupId) : null;
 
   const identifiers = {
     salesNavId: extractSalesNavId(data),
     numericId: numericId,
     linkedInUsername: extractLinkedInUsername(data),
-    duxsoupId: duxsoupId,
+    duxsoupId: normalizedDuxsoupId || duxsoupId,
     profileUrl: normalizeUrl(data.Profile || data.data?.Profile),
-    publicProfile: normalizeUrl(data.PublicProfile || data.data?.PublicProfile),
+    publicProfile:
+      normalizePublicProfileUrl(data.PublicProfile || data.data?.PublicProfile) ||
+      normalizePublicProfileUrl(data.Profile || data.data?.Profile) ||
+      normalizeUrl(data.PublicProfile || data.data?.PublicProfile),
     recruiterProfile: normalizeUrl(
       data.RecruiterProfile || data.data?.RecruiterProfile,
     ),
@@ -272,6 +321,8 @@ module.exports = {
   extractLinkedInUsername,
   extractSalesNavId,
   normalizeUrl,
+  normalizePublicProfileUrl,
+  normalizeDuxsoupId,
   extractIdentifiers,
   getPrimaryIdentifier,
   generateIdentityKey,

--- a/src/utils/identityResolver.js
+++ b/src/utils/identityResolver.js
@@ -224,9 +224,18 @@ function resolvePersonIdentity(webhookData) {
   const primary = identityMatcher.getPrimaryIdentifier(identifiers);
 
   const aliases = [];
+  const aliasKeys = new Set();
   let person_id = null;
   let source = null;
   let primaryIdType = null;
+
+  const addAlias = (type, value) => {
+    if (!value) return;
+    const key = `${type}:${value}`;
+    if (aliasKeys.has(key)) return;
+    aliasKeys.add(key);
+    aliases.push({ type, value });
+  };
 
   if (!primary) {
     logger.warn("No identifier found in webhook data", {
@@ -256,6 +265,7 @@ function resolvePersonIdentity(webhookData) {
   const sourceMapping = {
     linkedInUsername: "linkedInUsername",
     salesNavId: "salesNavId",
+    numericId: "numericId",
     profileUrl: "profileUrl",
     publicProfile: "publicUrl",
     recruiterProfile: "recruiterUrl",
@@ -266,30 +276,31 @@ function resolvePersonIdentity(webhookData) {
 
   // Build aliases from all extracted identifiers
   if (identifiers.linkedInUsername) {
-    aliases.push({
-      type: "linkedInUsername",
-      value: identifiers.linkedInUsername,
-    });
+    addAlias("linkedInUsername", identifiers.linkedInUsername);
   }
 
   if (identifiers.salesNavId) {
-    aliases.push({ type: "salesNavId", value: identifiers.salesNavId });
+    addAlias("salesNavId", identifiers.salesNavId);
+  }
+
+  if (identifiers.numericId) {
+    addAlias("numericId", identifiers.numericId);
   }
 
   if (identifiers.duxsoupId) {
-    aliases.push({ type: "duxsoupId", value: identifiers.duxsoupId });
+    addAlias("duxsoupId", identifiers.duxsoupId);
   }
 
   if (identifiers.profileUrl) {
-    aliases.push({ type: "profileUrl", value: identifiers.profileUrl });
+    addAlias("profileUrl", identifiers.profileUrl);
   }
 
   if (identifiers.publicProfile) {
-    aliases.push({ type: "publicUrl", value: identifiers.publicProfile });
+    addAlias("publicUrl", identifiers.publicProfile);
   }
 
   if (identifiers.recruiterProfile) {
-    aliases.push({ type: "recruiterUrl", value: identifiers.recruiterProfile });
+    addAlias("recruiterUrl", identifiers.recruiterProfile);
   }
 
   // Add original URL fields as aliases (normalized)
@@ -298,7 +309,7 @@ function resolvePersonIdentity(webhookData) {
       webhookData.SalesProfile,
     );
     if (normalizedSalesUrl) {
-      aliases.push({ type: "salesUrl", value: normalizedSalesUrl });
+      addAlias("salesUrl", normalizedSalesUrl);
     }
   }
 
@@ -307,8 +318,22 @@ function resolvePersonIdentity(webhookData) {
       webhookData.RecruiterProfile,
     );
     if (normalizedRecruiterUrl) {
-      aliases.push({ type: "recruiterUrl", value: normalizedRecruiterUrl });
+      addAlias("recruiterUrl", normalizedRecruiterUrl);
     }
+  }
+
+  const publicProfileFromUrl = identityMatcher.normalizePublicProfileUrl(
+    webhookData.Profile || webhookData.PublicProfile,
+  );
+  if (publicProfileFromUrl) {
+    addAlias("publicUrl", publicProfileFromUrl);
+  }
+
+  const normalizedDuxsoupId = identityMatcher.normalizeDuxsoupId(
+    webhookData.id || webhookData.data?.id,
+  );
+  if (normalizedDuxsoupId && normalizedDuxsoupId !== identifiers.duxsoupId) {
+    addAlias("duxsoupId", normalizedDuxsoupId);
   }
 
   // Log warning if using unstable identifier


### PR DESCRIPTION
### Motivation
- Improve reliability of identity resolution by normalizing LinkedIn/public URLs and DuxSoup IDs and by recognizing explicit username fields so stable identifiers are favored and cross-platform matching is stronger. 
- Capture numeric LinkedIn member IDs and normalized aliases to reduce duplicate people and improve merge accuracy. 
- Provide operational scripts to backfill normalized aliases and to review/merge high-confidence duplicate groups.

### Description
- Enhanced `src/utils/identityMatcher.js` to detect an explicit `LinkedInUsername` field, normalize `www` hostnames, provide `normalizePublicProfileUrl` and `normalizeDuxsoupId`, and include a `numericId` extraction in `extractIdentifiers`. 
- Updated `src/utils/identityResolver.js` to dedupe aliases via an `addAlias` helper, surface `numericId` aliases, add normalized public-profile aliases, and include normalized DuxSoup ID aliases during resolution. 
- Extended `src/models/person.js` schema with optional merge audit fields `mergedInto` and `mergedAt`. 
- Added two operational scripts: `scripts/backfill-alias-normalization.js` to backfill normalized aliases (dry-run/execute) and `scripts/merge-duplicates.js` to generate CSV review output and optionally execute merges. 
- Updated unit tests in `src/__tests__/identityResolver.test.js` to assert normalized profile URL output and numeric ID alias behavior.

### Testing
- Ran the identity resolver unit tests with `npm test -- identityResolver.test.js`, which passed: `31 tests, 31 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bea897e548332b85ba90ede7095fd)