### PR TITLE
Add salesNavId capitalization audit and standardization tooling

### DIFF
--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -158,7 +158,29 @@ Group 1/5:
 
 ---
 
-### Step 6: Merge Duplicates (Optional)
+### Step 6: Audit salesNavId capitalization
+
+Review capitalization patterns and optionally standardize aliases to the canonical
+Sales Navigator format (ACwAA/ACoAA). This does **not** change `canonical_id` values
+and preserves case-insensitive identity resolution.
+
+```bash
+# Audit only (no changes)
+node scripts/audit-salesnavid-case.js --dry-run
+
+# Standardize aliases to canonical case (in-place)
+node scripts/audit-salesnavid-case.js --execute
+```
+
+**Expected output includes:**
+- Total counts by capitalization category (canonical/lowercase/mixed/nonstandard)
+- Number of people with multiple case variants for the same salesNavId
+- Number of people with multiple distinct salesNavIds
+- Records updated when `--execute` is used
+
+---
+
+### Step 7: Merge Duplicates (Optional)
 
 If you're confident, auto-merge duplicates:
 
@@ -178,7 +200,7 @@ node scripts/identify-salesnavid-duplicates.js --auto-merge
 
 ---
 
-### Step 7: Verify Results
+### Step 8: Verify Results
 
 ```bash
 # Check salesNavId coverage
@@ -203,7 +225,7 @@ mongoose.connect(process.env.MONGO_URI).then(async () => {
 
 ---
 
-### Step 8: Deploy Code Changes
+### Step 9: Deploy Code Changes
 
 Once backfill is complete, deploy the updated code to production.
 

--- a/scripts/audit-salesnavid-case.js
+++ b/scripts/audit-salesnavid-case.js
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+/**
+ * Audit salesNavId capitalization patterns and optionally standardize aliases.
+ *
+ * Usage:
+ *   node scripts/audit-salesnavid-case.js --dry-run
+ *   node scripts/audit-salesnavid-case.js --execute
+ *   node scripts/audit-salesnavid-case.js --execute --limit=1000 --batch-size=200
+ */
+
+const mongoose = require('mongoose');
+require('dotenv').config();
+
+const Person = require('../src/models/person');
+const logger = require('../src/utils/logger');
+const { normalizeToCanonicalCase } = require('../src/utils/salesNavIdExtractor');
+
+const args = process.argv.slice(2);
+const isExecute = args.includes('--execute');
+const isDryRun = args.includes('--dry-run') || !isExecute;
+
+const limitArg = args.find((arg) => arg.startsWith('--limit='));
+const limit = limitArg ? parseInt(limitArg.split('=')[1], 10) : null;
+
+const batchArg = args.find((arg) => arg.startsWith('--batch-size='));
+const batchSize = batchArg ? parseInt(batchArg.split('=')[1], 10) : 250;
+
+function classifySalesNavId(value) {
+  if (!value || typeof value !== 'string') {
+    return 'missing';
+  }
+
+  const canonical = normalizeToCanonicalCase(value);
+  if (!canonical) {
+    return 'missing';
+  }
+
+  const hasCanonicalPrefix = /^(ACw|ACo)AA/.test(canonical);
+  if (value === canonical && hasCanonicalPrefix) {
+    return 'canonical';
+  }
+
+  if (value.toLowerCase() === canonical.toLowerCase()) {
+    if (value === value.toLowerCase()) {
+      return 'lowercase';
+    }
+    return 'mixed';
+  }
+
+  return 'nonstandard';
+}
+
+function normalizeSalesNavAliases(aliases = []) {
+  let changed = false;
+  const updated = [];
+  const seenSalesNav = new Set();
+
+  aliases.forEach((alias) => {
+    if (!alias?.type || !alias?.value) {
+      updated.push(alias);
+      return;
+    }
+
+    if (alias.type !== 'salesNavId') {
+      updated.push(alias);
+      return;
+    }
+
+    const canonical = normalizeToCanonicalCase(alias.value) || alias.value;
+    const key = `${alias.type}:${canonical}`;
+
+    if (seenSalesNav.has(key)) {
+      changed = true;
+      return;
+    }
+
+    if (canonical !== alias.value) {
+      changed = true;
+    }
+
+    seenSalesNav.add(key);
+    updated.push({
+      ...alias,
+      value: canonical,
+    });
+  });
+
+  return { updated, changed };
+}
+
+async function run() {
+  const mongoUri = process.env.MONGO_URI;
+  if (!mongoUri) {
+    throw new Error('MONGO_URI is not set');
+  }
+
+  await mongoose.connect(mongoUri, {
+    serverSelectionTimeoutMS: 30000,
+  });
+
+  logger.info('Connected to MongoDB');
+
+  if (limit) {
+    logger.info(`Limiting to ${limit} records`);
+  }
+
+  const cursor = Person.find({}).cursor();
+
+  let processed = 0;
+  let peopleWithSalesNav = 0;
+  let peopleWithCaseVariants = 0;
+  let peopleWithMultipleIds = 0;
+
+  const counts = {
+    canonical: 0,
+    lowercase: 0,
+    mixed: 0,
+    nonstandard: 0,
+    missing: 0,
+  };
+
+  const caseVariantKeys = new Map();
+  const pendingUpdates = [];
+  let updatedPeople = 0;
+
+  for await (const person of cursor) {
+    if (limit && processed >= limit) {
+      break;
+    }
+
+    processed += 1;
+    const aliases = person.aliases || [];
+    const salesNavAliases = aliases.filter(
+      (alias) => alias?.type === 'salesNavId' && alias?.value,
+    );
+
+    if (salesNavAliases.length === 0) {
+      counts.missing += 1;
+    } else {
+      peopleWithSalesNav += 1;
+    }
+
+    const normalizedKeys = new Map();
+    salesNavAliases.forEach((alias) => {
+      const classification = classifySalesNavId(alias.value);
+      counts[classification] += 1;
+
+      const canonical = normalizeToCanonicalCase(alias.value) || alias.value;
+      const key = canonical.toLowerCase();
+      const variants = normalizedKeys.get(key) || new Set();
+      variants.add(alias.value);
+      normalizedKeys.set(key, variants);
+    });
+
+    for (const [key, variants] of normalizedKeys.entries()) {
+      if (variants.size > 1) {
+        peopleWithCaseVariants += 1;
+        caseVariantKeys.set(key, (caseVariantKeys.get(key) || 0) + 1);
+        break;
+      }
+    }
+
+    if (normalizedKeys.size > 1) {
+      peopleWithMultipleIds += 1;
+    }
+
+    if (!isDryRun && salesNavAliases.length > 0) {
+      const { updated, changed } = normalizeSalesNavAliases(aliases);
+      if (changed) {
+        updatedPeople += 1;
+        pendingUpdates.push({
+          updateOne: {
+            filter: { _id: person._id },
+            update: { $set: { aliases: updated } },
+          },
+        });
+      }
+    }
+
+    if (!isDryRun && pendingUpdates.length >= batchSize) {
+      await Person.bulkWrite(pendingUpdates);
+      pendingUpdates.length = 0;
+    }
+  }
+
+  if (!isDryRun && pendingUpdates.length > 0) {
+    await Person.bulkWrite(pendingUpdates);
+  }
+
+  logger.info('salesNavId capitalization audit complete', {
+    processed,
+    peopleWithSalesNav,
+    peopleWithCaseVariants,
+    peopleWithMultipleIds,
+    caseVariantKeys: caseVariantKeys.size,
+    counts,
+    updatedPeople: isDryRun ? 0 : updatedPeople,
+    mode: isDryRun ? 'dry-run' : 'execute',
+  });
+
+  await mongoose.disconnect();
+}
+
+run().catch((error) => {
+  logger.error('salesNavId capitalization audit failed', { error: error.message });
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation

- Provide a safe way to discover capitalization patterns for `salesNavId` across the dataset to avoid URL-loading issues caused by incorrect case while preserving case-insensitive identity resolution. 
- Enable optional normalization of `salesNavId` aliases to LinkedIn's canonical mixed-case format (e.g. `ACwAA...` / `ACoAA...`) without changing `canonical_id` values.

### Description

- Add a new script `scripts/audit-salesnavid-case.js` that audits `salesNavId` aliases, classifies capitalization into `canonical`, `lowercase`, `mixed`, `nonstandard`, and `missing`, detects per-person case variants and multiple distinct salesNavIds, and can optionally normalize aliases to canonical case in-place with `--execute` (dry-run by default). 
- The script uses `normalizeToCanonicalCase` from `src/utils/salesNavIdExtractor.js`, supports `--limit` and `--batch-size`, writes updates with `Person.bulkWrite`, and deduplicates salesNavId aliases when normalizing. 
- Update `docs/MIGRATION_GUIDE.md` to document the audit/standardization workflow and add commands/examples for `node scripts/audit-salesnavid-case.js` (dry-run and execute), and adjust subsequent step numbering in the guide.

### Testing

- No automated tests were executed as part of this change (dry-run recommended before `--execute`).
- Recommended validation commands are documented in `docs/MIGRATION_GUIDE.md`, for example `node scripts/audit-salesnavid-case.js --dry-run` to inspect results without making changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ca855b3788332a25b5df0a6b5d3e4)